### PR TITLE
Feature/#3 seo0h temp 필터링 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@chakra-ui/icons": "^2.0.17",
         "@chakra-ui/react": "^2.5.1",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
@@ -19,6 +20,7 @@
         "@types/node": "^16.18.14",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
+        "axios": "^1.3.4",
         "framer-motion": "^10.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2161,6 +2163,18 @@
       "integrity": "sha512-RpA1X5Ptz8Mt39HSyEIW1wxAz2AXyf9H0JJ5HVx/dBdMZaGMDJ0HyyPBVci0m4RCoJuyG1HHG/DXJaVfUTVAeg==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.0.17.tgz",
+      "integrity": "sha512-HMJP0WrJgAmFR9+Xh/CBH0nVnGMsJ4ZC8MK6tMgxPKd9/muvn0I4hsicHqdPlLpmB0TlxlhkBAKaVMtOdz6F0w==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.0.16"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -6166,6 +6180,29 @@
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -15354,6 +15391,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -20175,6 +20217,14 @@
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
+    "@chakra-ui/icons": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.0.17.tgz",
+      "integrity": "sha512-HMJP0WrJgAmFR9+Xh/CBH0nVnGMsJ4ZC8MK6tMgxPKd9/muvn0I4hsicHqdPlLpmB0TlxlhkBAKaVMtOdz6F0w==",
+      "requires": {
+        "@chakra-ui/icon": "3.0.16"
+      }
+    },
     "@chakra-ui/image": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.0.15.tgz",
@@ -23092,6 +23142,28 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg=="
+    },
+    "axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "3.1.1",
@@ -29575,6 +29647,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@chakra-ui/icons": "^2.0.17",
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
@@ -13,6 +14,7 @@
     "@types/node": "^16.18.14",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
+    "axios": "^1.3.4",
     "framer-motion": "^10.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/FilterContent.tsx
+++ b/src/components/FilterContent.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Tag,
+  HStack,
+  Text,
+  RangeSlider,
+  RangeSliderTrack,
+  RangeSliderFilledTrack,
+  RangeSliderThumb,
+} from '@chakra-ui/react';
+
+import { travleContent } from './../types/index.d';
+
+interface FilterContentProps {
+  data: travleContent[];
+  locationArr: string[];
+  onClick: (e: React.MouseEvent) => void;
+}
+
+const FilterContent = ({ onClick, locationArr }: FilterContentProps) => {
+  return (
+    <Box
+      width={'725.33px'}
+      zIndex={2}
+      position={'fixed'}
+      borderWidth='1px'
+      borderRadius='lg'
+      background={'white'}
+      minH={'150px'}
+      top={'20px'}
+      padding={'10px 100px'}
+    >
+      <Text>지역</Text>
+      <HStack spacing={4}>
+        {locationArr.map(e => {
+          return (
+            <Tag
+              key={e}
+              size={'lg'}
+              variant='subtle'
+              colorScheme='cyan'
+              onClick={e => onClick(e)}
+              cursor={'pointer'}
+            >
+              {e}
+            </Tag>
+          );
+        })}
+      </HStack>
+      <RangeSlider defaultValue={[120, 240]} min={0} max={300} step={30}>
+        <RangeSliderTrack>
+          <RangeSliderFilledTrack />
+        </RangeSliderTrack>
+        <RangeSliderThumb boxSize={6} index={0} />
+        <RangeSliderThumb boxSize={6} index={1} />
+      </RangeSlider>
+      <Text>hi</Text>
+    </Box>
+  );
+};
+
+export default FilterContent;

--- a/src/components/TravleContent.tsx
+++ b/src/components/TravleContent.tsx
@@ -17,7 +17,7 @@ import {
 } from '@chakra-ui/react';
 import { travleContent } from 'types';
 import TravleDetailModal from 'components/modal/TravleDetailModal';
-import { useBasketDispatch, useBasketState } from 'components/context/BasketProvider';
+import { ActionName, useBasketDispatch, useBasketState } from 'components/context/BasketProvider';
 
 const TravleContent = ({
   idx,
@@ -45,7 +45,7 @@ const TravleContent = ({
 
   const addItem = () => {
     dispatch({
-      type: 'ADD_ITEM',
+      type: ActionName.ADD_ITEM,
       item: {
         idx,
         name,

--- a/src/components/TravleContent.tsx
+++ b/src/components/TravleContent.tsx
@@ -8,8 +8,10 @@ import {
   Divider,
   GridItem,
   Heading,
+  HStack,
   Image,
   Stack,
+  Tag,
   Text,
   useDisclosure,
 } from '@chakra-ui/react';
@@ -31,12 +33,15 @@ const TravleContent = ({
   const dispatch = useBasketDispatch();
   const basket = useBasketState();
   const [isMaximum, setIsMaximum] = useState(false);
+  const [count, setCount] = useState<number>(0);
 
   useEffect(() => {
     if (basket.filter(product => product.idx === idx).length >= maximumPurchases)
       setIsMaximum(true);
     else setIsMaximum(false);
   }, [basket]);
+
+  const getCount = () => setCount(basket.filter(e => e.idx === idx).length);
 
   const addItem = () => {
     dispatch({
@@ -54,6 +59,9 @@ const TravleContent = ({
     });
   };
 
+  useEffect(() => {
+    getCount();
+  }, [addItem]);
   return (
     <GridItem>
       <Card maxW={'sm'} variant='outline'>
@@ -61,7 +69,10 @@ const TravleContent = ({
           <Image src={mainImage} alt='product image' fit={'fill'} htmlWidth='100%' />
           <Stack mt={6} spacing={3}>
             <Heading size={'sm'}>{name}</Heading>
-            <Text>상품번호:{idx}</Text>
+            <HStack>
+              <Tag>상품번호: {idx}</Tag>
+              <Tag>남은 수량: {maximumPurchases - count}</Tag>
+            </HStack>
             <Text>사용가능 지역:{spaceCategory}</Text>
             <Text fontSize='2xl'>{price.toLocaleString('ko-KR')}원</Text>
           </Stack>

--- a/src/components/context/BasketProvider.tsx
+++ b/src/components/context/BasketProvider.tsx
@@ -1,9 +1,14 @@
 import React, { createContext, Dispatch, ReactNode, useContext, useReducer } from 'react';
 import { travleContent } from 'types';
 
+export enum ActionName {
+  ADD_ITEM = 'ADD_ITEM',
+  DELETE_ITEM = 'DELETE_ITEM',
+}
+
 type Action =
-  | { type: 'ADD_ITEM'; item: travleContent }
-  | { type: 'DELETE_ITEM'; item: travleContent };
+  | { type: ActionName.ADD_ITEM; item: travleContent }
+  | { type: ActionName.DELETE_ITEM; item: travleContent };
 
 type ActionDispatch = Dispatch<Action>;
 type BasketState = travleContent[];
@@ -12,12 +17,12 @@ export const BasketDispatchContext = createContext<ActionDispatch | null>(null);
 
 function reducer(state: travleContent[], action: Action): BasketState {
   switch (action.type) {
-    case 'ADD_ITEM':
+    case ActionName.ADD_ITEM:
       const addData = [...state];
       addData.push(action.item);
       localStorage.setItem('shopping-basket', JSON.stringify(addData));
       return addData;
-    case 'DELETE_ITEM':
+    case ActionName.DELETE_ITEM:
       const deleteData = [...state];
       deleteData.splice(
         deleteData.findIndex(v => v.idx === action.item.idx),

--- a/src/components/context/BasketProvider.tsx
+++ b/src/components/context/BasketProvider.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, Dispatch, ReactNode, useContext, useReducer } from 'react';
 import { travleContent } from 'types';
 
-export enum ActionName {
+export const enum ActionName {
   ADD_ITEM = 'ADD_ITEM',
   DELETE_ITEM = 'DELETE_ITEM',
 }

--- a/src/components/reservations/ReservationsContent.tsx
+++ b/src/components/reservations/ReservationsContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Box,
   Button,
@@ -6,8 +6,10 @@ import {
   Card,
   CardBody,
   CardFooter,
+  CardHeader,
   Center,
   Divider,
+  Flex,
   Grid,
   GridItem,
   Heading,
@@ -16,28 +18,75 @@ import {
   Stack,
   Text,
   useDisclosure,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
+  useMergeRefs,
 } from '@chakra-ui/react';
-import { PhoneIcon, AddIcon, WarningIcon, MinusIcon } from '@chakra-ui/icons';
+import { PhoneIcon, AddIcon, WarningIcon, MinusIcon, CloseIcon } from '@chakra-ui/icons';
 import { travleContent } from 'types';
+import { useBasketDispatch, useBasketState } from 'components/context/BasketProvider';
 
 const ReservationsContent = ({
   idx,
   name,
   mainImage,
-  description,
   spaceCategory,
+  description,
   price,
   maximumPurchases,
   registrationDate,
 }: travleContent) => {
+  const baskets = useBasketState();
+  const dispatch = useBasketDispatch();
+
+  const [isMax, setIsMax] = useState(false);
+  const [count, setCount] = useState<number>(0);
+
+  const getCount = () => setCount(baskets.filter(e => e.idx === idx).length);
+
+  const val = {
+    idx,
+    name,
+    mainImage,
+    description,
+    spaceCategory,
+    price,
+    maximumPurchases,
+    registrationDate,
+  };
+
+  useEffect(() => {
+    getCount();
+  }, [baskets]);
+
+  const onAddItem = () => {
+    dispatch({
+      type: 'ADD_ITEM',
+      item: {
+        ...val,
+      },
+    });
+  };
+
+  const onMinusItem = () => {
+    dispatch({
+      type: 'DELETE_ITEM',
+      item: {
+        ...val,
+      },
+    });
+  };
+
+  const allDelete = () => {
+    baskets.forEach(e => e.idx === idx && dispatch({ type: 'DELETE_ITEM', item: { ...e } }));
+  };
+
   return (
     <Card minH={'150px'} minW={'900px'} variant='outline' direction={'row'} overflow='hidden'>
-      <Image
-        src={'https://picsum.photos/id/17/300/300'}
-        alt='product image'
-        maxH={'200'}
-        object-fit='cover'
-      />
+      <Image src={mainImage} alt='product image' maxH={'200'} object-fit='cover' />
 
       <Grid templateColumns='repeat(2, 1fr)' paddingLeft={'3'} alignContent={'center'}>
         <CardBody width={'400px'}>
@@ -46,25 +95,35 @@ const ReservationsContent = ({
           </Heading>
           <Text fontSize='xl'>{price.toLocaleString('ko-KR')}원</Text>
         </CardBody>
-
-        <Center minW={'200px'} marginRight={'1'}>
+        <ButtonGroup>
           <IconButton
             size='lg'
-            colorScheme={'gray'}
             icon={<AddIcon />}
-            aria-label={'Add Purchases'}
+            aria-label={'Add Item'}
+            marginTop={'3'}
             marginRight={'3'}
+            onClick={onAddItem}
           />
-          <Text fontSize='xl'>개수</Text>
+          <Text> {count}</Text>
           <IconButton
             size='lg'
-            colorScheme={'gray'}
             icon={<MinusIcon />}
-            aria-label={'Minus Purchases'}
-            marginLeft={'3'}
+            aria-label={'Minus Item'}
+            marginTop={'3'}
+            marginRight={'3'}
+            onClick={onMinusItem}
           />
-        </Center>
+        </ButtonGroup>
       </Grid>
+      <IconButton
+        size='lg'
+        background={'none'}
+        icon={<CloseIcon />}
+        aria-label={'Delet Item'}
+        marginTop={'3'}
+        marginRight={'3'}
+        onClick={allDelete}
+      />
     </Card>
   );
 };

--- a/src/components/reservations/ReservationsContent.tsx
+++ b/src/components/reservations/ReservationsContent.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Card,
+  CardBody,
+  CardFooter,
+  Center,
+  Divider,
+  Grid,
+  GridItem,
+  Heading,
+  IconButton,
+  Image,
+  Stack,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { PhoneIcon, AddIcon, WarningIcon, MinusIcon } from '@chakra-ui/icons';
+import { travleContent } from 'types';
+
+const ReservationsContent = ({
+  idx,
+  name,
+  mainImage,
+  description,
+  spaceCategory,
+  price,
+  maximumPurchases,
+  registrationDate,
+}: travleContent) => {
+  return (
+    <Card minH={'150px'} minW={'900px'} variant='outline' direction={'row'} overflow='hidden'>
+      <Image
+        src={'https://picsum.photos/id/17/300/300'}
+        alt='product image'
+        maxH={'200'}
+        object-fit='cover'
+      />
+
+      <Grid templateColumns='repeat(2, 1fr)' paddingLeft={'3'} alignContent={'center'}>
+        <CardBody width={'400px'}>
+          <Heading size={'sm'} fontSize='1.5rem' marginBottom={'8'}>
+            {name}
+          </Heading>
+          <Text fontSize='xl'>{price.toLocaleString('ko-KR')}원</Text>
+        </CardBody>
+
+        <Center minW={'200px'} marginRight={'1'}>
+          <IconButton
+            size='lg'
+            colorScheme={'gray'}
+            icon={<AddIcon />}
+            aria-label={'Add Purchases'}
+            marginRight={'3'}
+          />
+          <Text fontSize='xl'>개수</Text>
+          <IconButton
+            size='lg'
+            colorScheme={'gray'}
+            icon={<MinusIcon />}
+            aria-label={'Minus Purchases'}
+            marginLeft={'3'}
+          />
+        </Center>
+      </Grid>
+    </Card>
+  );
+};
+
+export default ReservationsContent;

--- a/src/components/reservations/ReservationsContent.tsx
+++ b/src/components/reservations/ReservationsContent.tsx
@@ -51,29 +51,24 @@ const ReservationsContent = ({
     } else {
       dispatch({
         type: ActionName.ADD_ITEM,
-        item: {
-          ...val,
-        },
+        item: { ...val },
       });
     }
   };
 
   const onMinusItem = () => {
-    if (count <= 1) {
-      alert('최소 주문 수량은 1개 입니다.');
-    } else {
+    if (count <= 1) alert('최소 주문 수량은 1개 입니다.');
+    else {
       dispatch({
         type: ActionName.DELETE_ITEM,
-        item: {
-          ...val,
-        },
+        item: { ...val },
       });
     }
   };
 
   const allDelete = () => {
     baskets.forEach(
-      e => e.idx === idx && dispatch({ type: ActionName.DELETE_ITEM, item: { ...e } }),
+      data => data.idx === idx && dispatch({ type: ActionName.DELETE_ITEM, item: { ...data } }),
     );
   };
 

--- a/src/components/reservations/ReservationsContent.tsx
+++ b/src/components/reservations/ReservationsContent.tsx
@@ -12,7 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { AddIcon, MinusIcon, CloseIcon } from '@chakra-ui/icons';
 import { travleContent } from 'types';
-import { useBasketDispatch, useBasketState } from 'components/context/BasketProvider';
+import { ActionName, useBasketDispatch, useBasketState } from 'components/context/BasketProvider';
 
 const ReservationsContent = ({
   idx,
@@ -50,7 +50,7 @@ const ReservationsContent = ({
       alert('최대 수량을 넘겨 담을 수 없습니다.');
     } else {
       dispatch({
-        type: 'ADD_ITEM',
+        type: ActionName.ADD_ITEM,
         item: {
           ...val,
         },
@@ -63,7 +63,7 @@ const ReservationsContent = ({
       alert('최소 주문 수량은 1개 입니다.');
     } else {
       dispatch({
-        type: 'DELETE_ITEM',
+        type: ActionName.DELETE_ITEM,
         item: {
           ...val,
         },
@@ -72,7 +72,9 @@ const ReservationsContent = ({
   };
 
   const allDelete = () => {
-    baskets.forEach(e => e.idx === idx && dispatch({ type: 'DELETE_ITEM', item: { ...e } }));
+    baskets.forEach(
+      e => e.idx === idx && dispatch({ type: ActionName.DELETE_ITEM, item: { ...e } }),
+    );
   };
 
   return (

--- a/src/components/reservations/ReservationsContent.tsx
+++ b/src/components/reservations/ReservationsContent.tsx
@@ -1,31 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
-  Box,
-  Button,
   ButtonGroup,
   Card,
   CardBody,
-  CardFooter,
-  CardHeader,
-  Center,
-  Divider,
-  Flex,
   Grid,
-  GridItem,
-  Heading,
   IconButton,
   Image,
-  Stack,
   Text,
-  useDisclosure,
-  NumberInput,
-  NumberInputField,
-  NumberInputStepper,
-  NumberIncrementStepper,
-  NumberDecrementStepper,
-  useMergeRefs,
+  Tag,
+  HStack,
 } from '@chakra-ui/react';
-import { PhoneIcon, AddIcon, WarningIcon, MinusIcon, CloseIcon } from '@chakra-ui/icons';
+import { AddIcon, MinusIcon, CloseIcon } from '@chakra-ui/icons';
 import { travleContent } from 'types';
 import { useBasketDispatch, useBasketState } from 'components/context/BasketProvider';
 
@@ -41,8 +26,6 @@ const ReservationsContent = ({
 }: travleContent) => {
   const baskets = useBasketState();
   const dispatch = useBasketDispatch();
-
-  const [isMax, setIsMax] = useState(false);
   const [count, setCount] = useState<number>(0);
 
   const getCount = () => setCount(baskets.filter(e => e.idx === idx).length);
@@ -63,21 +46,29 @@ const ReservationsContent = ({
   }, [baskets]);
 
   const onAddItem = () => {
-    dispatch({
-      type: 'ADD_ITEM',
-      item: {
-        ...val,
-      },
-    });
+    if (count >= maximumPurchases) {
+      alert('최대 수량을 넘겨 담을 수 없습니다.');
+    } else {
+      dispatch({
+        type: 'ADD_ITEM',
+        item: {
+          ...val,
+        },
+      });
+    }
   };
 
   const onMinusItem = () => {
-    dispatch({
-      type: 'DELETE_ITEM',
-      item: {
-        ...val,
-      },
-    });
+    if (count <= 1) {
+      alert('최소 주문 수량은 1개 입니다.');
+    } else {
+      dispatch({
+        type: 'DELETE_ITEM',
+        item: {
+          ...val,
+        },
+      });
+    }
   };
 
   const allDelete = () => {
@@ -90,12 +81,22 @@ const ReservationsContent = ({
 
       <Grid templateColumns='repeat(2, 1fr)' paddingLeft={'3'} alignContent={'center'}>
         <CardBody width={'400px'}>
-          <Heading size={'sm'} fontSize='1.5rem' marginBottom={'8'}>
+          <Text fontSize={'2xl'} fontWeight={'bold'} marginBottom='2'>
             {name}
-          </Heading>
-          <Text fontSize='xl'>{price.toLocaleString('ko-KR')}원</Text>
+          </Text>
+          <HStack spacing={'4'} marginBottom='6'>
+            <Tag fontWeight={'bold'} size={'md'}>
+              {spaceCategory}
+            </Tag>
+            <Tag fontWeight={'bold'} size={'md'}>
+              남은 수량: {maximumPurchases - count}
+            </Tag>
+          </HStack>
+          <Text size='xl' fontSize={'1.5rem'} fontWeight='medium'>
+            {price.toLocaleString('ko-KR')}원
+          </Text>
         </CardBody>
-        <ButtonGroup>
+        <ButtonGroup alignItems={'center'}>
           <IconButton
             size='lg'
             icon={<AddIcon />}
@@ -104,7 +105,9 @@ const ReservationsContent = ({
             marginRight={'3'}
             onClick={onAddItem}
           />
-          <Text> {count}</Text>
+          <Text fontSize={'2xl'} fontWeight={'bold'} align={'center'} marginRight='3'>
+            {count}
+          </Text>
           <IconButton
             size='lg'
             icon={<MinusIcon />}

--- a/src/pages/ReservationPage.tsx
+++ b/src/pages/ReservationPage.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { Box, Button, Card, CardBody, CardFooter, Grid, Heading, Text } from '@chakra-ui/react';
+import MainLayout from 'components/MainLayout';
+import TravleContent from 'components/TravleContent';
+
+import { useLoaderData } from 'react-router-dom';
+import { travleContent } from 'types';
+import ReservationsContent from 'components/reservations/ReservationsContent';
+
+const ReservationPage = () => {
+  const data = JSON.parse(localStorage.getItem('shopping-basket') || '') as travleContent[];
+
+  return (
+    <MainLayout>
+      <Grid templateColumns='1fr 400px'>
+        <Box as='section'>
+          <Grid templateColumns='repeat(1,1fr)' gap={10}>
+            {data.map(product => (
+              <ReservationsContent {...product} key={product.idx} />
+            ))}
+          </Grid>
+        </Box>
+        <Card marginLeft={'10'} maxH={'200px'} variant='outline' overflow='hidden'>
+          <CardBody>
+            <Heading>결제금액</Heading>
+          </CardBody>
+          <Button>결제하기</Button>
+        </Card>
+      </Grid>
+    </MainLayout>
+  );
+};
+
+export default ReservationPage;

--- a/src/pages/ReservationPage.tsx
+++ b/src/pages/ReservationPage.tsx
@@ -1,29 +1,67 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Box, Button, Card, CardBody, CardFooter, Grid, Heading, Text } from '@chakra-ui/react';
 import MainLayout from 'components/MainLayout';
 import TravleContent from 'components/TravleContent';
 
-import { useLoaderData } from 'react-router-dom';
+import { Link, Navigate, useLoaderData } from 'react-router-dom';
 import { travleContent } from 'types';
 import ReservationsContent from 'components/reservations/ReservationsContent';
+import { useBasketState } from 'components/context/BasketProvider';
+
+// const basket = getData ? (JSON.parse(getData || '') as travleContent[]) : null;
 
 const ReservationPage = () => {
-  const data = JSON.parse(localStorage.getItem('shopping-basket') || '') as travleContent[];
+  const basket = useBasketState();
+  const [delDupleData, setDupleData] = useState<travleContent[]>([]);
+  const [totalPrice, setTotalPrice] = useState<number>(0);
+  let idxCounterArr = [] as number[];
+
+  useEffect(() => {
+    // SUM TOTAL PRICE & COUNT ITEM
+    if (basket.length > 0) {
+      const maxIdx = basket.sort((a, b) => a.idx - b.idx)[0].idx;
+      idxCounterArr = new Array(maxIdx + 1).fill(0);
+
+      let price = 0;
+      basket.forEach(el => {
+        idxCounterArr[el.idx]++;
+        price += el.price;
+      });
+      setTotalPrice(price);
+
+      const delDupleDataArr = [] as travleContent[];
+      basket.forEach(el => {
+        if (!delDupleDataArr.find(val => val.idx === el.idx)) delDupleDataArr.push(el);
+      });
+      setDupleData(delDupleDataArr);
+    }
+  }, [basket]);
 
   return (
     <MainLayout>
       <Grid templateColumns='1fr 400px'>
         <Box as='section'>
+          <Link to='/main'>
+            <Button marginBottom={'3'} minW={'200px'}>
+              홈으로 돌아가기
+            </Button>
+          </Link>
           <Grid templateColumns='repeat(1,1fr)' gap={10}>
-            {data.map(product => (
-              <ReservationsContent {...product} key={product.idx} />
-            ))}
+            {basket.length === 0 ? (
+              <div>데이터가 없습니다</div>
+            ) : (
+              delDupleData.map(product => {
+                return <ReservationsContent {...product} key={product.idx} />;
+              })
+            )}
           </Grid>
         </Box>
         <Card marginLeft={'10'} maxH={'200px'} variant='outline' overflow='hidden'>
           <CardBody>
-            <Heading>결제금액</Heading>
+            <Heading size={'md'} fontSize={'2rem'}>
+              결제금액 : {totalPrice.toLocaleString('ko-KR')} 원{' '}
+            </Heading>
           </CardBody>
           <Button>결제하기</Button>
         </Card>

--- a/src/pages/ReservationPage.tsx
+++ b/src/pages/ReservationPage.tsx
@@ -16,23 +16,25 @@ const ReservationPage = () => {
   let idxCounterArr = [] as number[];
 
   useEffect(() => {
-    // SUM TOTAL PRICE & COUNT ITEM
     if (basket.length > 0) {
       const maxIdx = basket.sort((a, b) => a.idx - b.idx)[0].idx;
       idxCounterArr = new Array(maxIdx + 1).fill(0);
-
       let price = 0;
+
+      // SUM TOTAL PRICE & COUNT ITEM
       basket.forEach(el => {
         idxCounterArr[el.idx]++;
         price += el.price;
       });
       setTotalPrice(price);
 
-      const delDupleDataArr = [] as travleContent[];
-      basket.forEach(el => {
-        if (!delDupleDataArr.find(val => val.idx === el.idx)) delDupleDataArr.push(el);
-      });
-      setDupleData(delDupleDataArr);
+      // FILTERS DUPLICATE ITEM
+      setDupleData(
+        basket.reduce<travleContent[]>((arr, cur) => {
+          if (!arr.find(val => val.idx === cur.idx)) arr.push(cur);
+          return arr;
+        }, []),
+      );
     }
   }, [basket]);
 

--- a/src/pages/ReservationPage.tsx
+++ b/src/pages/ReservationPage.tsx
@@ -1,15 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
-import { Box, Button, Card, CardBody, CardFooter, Grid, Heading, Text } from '@chakra-ui/react';
+import { Box, Button, Card, CardBody, Grid, Heading, Text } from '@chakra-ui/react';
 import MainLayout from 'components/MainLayout';
-import TravleContent from 'components/TravleContent';
 
-import { Link, Navigate, useLoaderData } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { travleContent } from 'types';
 import ReservationsContent from 'components/reservations/ReservationsContent';
 import { useBasketState } from 'components/context/BasketProvider';
-
-// const basket = getData ? (JSON.parse(getData || '') as travleContent[]) : null;
+import { ArrowBackIcon } from '@chakra-ui/icons';
 
 const ReservationPage = () => {
   const basket = useBasketState();
@@ -43,8 +41,9 @@ const ReservationPage = () => {
       <Grid templateColumns='1fr 400px'>
         <Box as='section'>
           <Link to='/main'>
-            <Button marginBottom={'3'} minW={'200px'}>
-              홈으로 돌아가기
+            <Button marginBottom={'3'} minW={'200px'} fontSize='m'>
+              <ArrowBackIcon boxSize={'1.5rem'} marginRight={'2'} />
+              <Text>홈으로 돌아가기</Text>
             </Button>
           </Link>
           <Grid templateColumns='repeat(1,1fr)' gap={10}>
@@ -57,13 +56,22 @@ const ReservationPage = () => {
             )}
           </Grid>
         </Box>
-        <Card marginLeft={'10'} maxH={'200px'} variant='outline' overflow='hidden'>
+
+        <Card marginLeft={'10'} maxH={'200px'} top={'52px'} variant='outline' overflow='hidden'>
           <CardBody>
             <Heading size={'md'} fontSize={'2rem'}>
               결제금액 : {totalPrice.toLocaleString('ko-KR')} 원{' '}
             </Heading>
           </CardBody>
-          <Button>결제하기</Button>
+          <Button
+            bgColor={'gray.700'}
+            color={'gray.100'}
+            colorScheme='blackAlpha'
+            minH='60px'
+            fontSize={'2xl'}
+          >
+            결제하기
+          </Button>
         </Card>
       </Grid>
     </MainLayout>

--- a/src/pages/Styles.tsx
+++ b/src/pages/Styles.tsx
@@ -1,0 +1,35 @@
+import React, { ReactNode } from 'react';
+import { Box, ChakraComponent, Tag, TagProps } from '@chakra-ui/react';
+
+export const FilterBox = ({ children }: { children: ReactNode }) => {
+  return (
+    <Box
+      width={'725.33px'}
+      zIndex={2}
+      position={'fixed'}
+      borderWidth='1px'
+      borderRadius='lg'
+      background={'white'}
+      minH={'180px'}
+      top={'20px'}
+      padding={'10px 100px'}
+      shadow={'3px 3px 5px #cacaca5c'}
+    >
+      {children}
+    </Box>
+  );
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type DivComponent = ChakraComponent<'div', {}>;
+
+export const MyCustomTag = ((props: TagProps) => (
+  <Tag
+    size={'lg'}
+    variant='subtle'
+    colorScheme='blackAlpha'
+    cursor={'pointer'}
+    fontWeight='black'
+    {...props}
+  />
+)) as DivComponent;

--- a/src/pages/Styles.tsx
+++ b/src/pages/Styles.tsx
@@ -6,7 +6,6 @@ export const FilterBox = ({ children }: { children: ReactNode }) => {
     <Box
       width={'725.33px'}
       zIndex={2}
-      position={'fixed'}
       borderWidth='1px'
       borderRadius='lg'
       background={'white'}

--- a/src/pages/TravleListPage.tsx
+++ b/src/pages/TravleListPage.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Box, Grid } from '@chakra-ui/react';
+import { Box, Grid, Button } from '@chakra-ui/react';
 import MainLayout from 'components/MainLayout';
 import TravleContent from 'components/TravleContent';
 
-import { useLoaderData } from 'react-router-dom';
+import { useLoaderData, Link } from 'react-router-dom';
 import { travleContent } from 'types';
 
 const Main = () => {
@@ -11,6 +11,11 @@ const Main = () => {
   return (
     <MainLayout>
       <Box as='section'>
+        <Link to='/reservations'>
+          <Button marginBottom={'3'} minW={'200px'}>
+            장바구니
+          </Button>
+        </Link>
         <Grid templateColumns='repeat(2,1fr)' gap={10}>
           {data.map(product => (
             <TravleContent {...product} key={product.idx} />

--- a/src/pages/TravleListPage.tsx
+++ b/src/pages/TravleListPage.tsx
@@ -21,60 +21,60 @@ import { travleContent } from 'types';
 import { CheckIcon } from '@chakra-ui/icons';
 import { FilterBox, MyCustomTag } from './Styles';
 
-enum StateSelect {
-  ALL_SLELCT = '전체 선택하기',
-}
+const INNER_HTML = {
+  ALL_SLELCT: '전체 선택하기',
+} as const;
 
-const setSelectLocation = new Set();
-const priceRange = [0, 0];
+const setUserSelectLocation = new Set();
+const dataPriceRange = [0, 0];
 
 const Main = () => {
-  const data = useLoaderData() as travleContent[];
-  const [filteredData, setFilteredData] = useState(data);
-  const [locationArr, setLocationArr] = useState<string[]>([]);
-  const [minMaxPrice, setMinMaxPrice] = useState<number[]>([0, 0]);
+  const datas = useLoaderData() as travleContent[];
+
+  const [filteredDatas, setFilteredData] = useState(datas);
+  const [showLocationArr, setShowLocationArr] = useState<string[]>([]);
+  const [userMinMaxPrice, setUserMinMaxPrice] = useState<number[]>([0, 0]);
 
   useEffect(() => {
-    setLocationArr(
-      data.reduce<string[]>((acc, cur) => {
+    // DETERMINED SPACECATEGORY OF THE DATA
+    setShowLocationArr(
+      datas.reduce<string[]>((acc, cur) => {
         if (!acc.includes(cur.spaceCategory)) acc.push(cur.spaceCategory);
         return acc;
       }, []),
     );
   }, []);
 
-  let min = data[0].price;
-  let max = data[0].price;
-  data.forEach(e => {
-    if (e.price < min) min = e.price;
-    else if (e.price > max) max = e.price;
+  // DETERMINED MIN MAX PRICE OF THE DATA
+  let min = datas[0].price;
+  let max = datas[0].price;
+  datas.forEach(data => {
+    data.price < min ? (min = data.price) : (max = data.price);
   });
-  priceRange[0] = min;
-  priceRange[1] = max;
+  dataPriceRange[0] = min;
+  dataPriceRange[1] = max;
 
   useEffect(() => {
-    setMinMaxPrice([min, max]);
+    setUserMinMaxPrice([min, max]);
   }, []);
 
-  const onClick = (e: React.MouseEvent) => {
+  // FILTERING SPACECATEGORY
+  const onTagClick = (e: React.MouseEvent) => {
     const element = e.target as HTMLElement;
-    if (element.innerHTML === StateSelect.ALL_SLELCT) {
-      locationArr.forEach(e => setSelectLocation.add(e));
+    if (element.innerHTML === INNER_HTML.ALL_SLELCT) {
+      showLocationArr.forEach(e => setUserSelectLocation.add(e));
     } else {
-      setSelectLocation.has(element.innerHTML)
-        ? setSelectLocation.delete(element.innerHTML)
-        : setSelectLocation.add(element.innerHTML);
+      setUserSelectLocation.has(element.innerHTML)
+        ? setUserSelectLocation.delete(element.innerHTML)
+        : setUserSelectLocation.add(element.innerHTML);
     }
-
-    const filtered = data.filter(cur => setSelectLocation.has(cur.spaceCategory));
-
-    setFilteredData(filtered);
+    setFilteredData(datas.filter(cur => setUserSelectLocation.has(cur.spaceCategory)));
   };
 
   const onChange = (e: number[]) => {
     const [min, max] = e;
-    setFilteredData(data.filter(e => e.price >= min && e.price <= max));
-    setMinMaxPrice([min, max]);
+    setFilteredData(datas.filter(e => e.price >= min && e.price <= max));
+    setUserMinMaxPrice([min, max]);
   };
 
   return (
@@ -84,19 +84,19 @@ const Main = () => {
           위치 필터
         </Heading>
         <HStack spacing={4} marginBottom={'20px'}>
-          {locationArr.map(e => {
+          {showLocationArr.map(location => {
             return (
               <MyCustomTag
-                key={e}
-                bg={setSelectLocation.has(e) ? 'gray.400' : 'gray.200'}
-                onClick={e => onClick(e)}
+                key={location}
+                bg={setUserSelectLocation.has(location) ? 'gray.400' : 'gray.200'}
+                onClick={location => onTagClick(location)}
               >
-                {e}
+                {location}
               </MyCustomTag>
             );
           })}
-          <MyCustomTag bg={'gray.200'} onClick={e => onClick(e)}>
-            {StateSelect.ALL_SLELCT}
+          <MyCustomTag bg={'gray.200'} onClick={e => onTagClick(e)}>
+            {INNER_HTML.ALL_SLELCT}
           </MyCustomTag>
         </HStack>
         <Divider marginBottom={'8'} />
@@ -105,25 +105,30 @@ const Main = () => {
         </Heading>
         <RangeSlider
           aria-label={['min', 'max']}
-          defaultValue={[priceRange[0], priceRange[1]]}
-          min={priceRange[0]}
-          max={priceRange[1]}
+          defaultValue={[dataPriceRange[0], dataPriceRange[1]]}
+          min={dataPriceRange[0]}
+          max={dataPriceRange[1]}
           step={1000}
           marginTop={'20px'}
           marginBottom={'20px'}
           onChange={e => onChange(e)}
         >
-          <RangeSliderMark value={priceRange[0]} mt='4' ml='-2.5' fontSize='sm'>
-            {priceRange[0].toLocaleString()}
-          </RangeSliderMark>
-          <RangeSliderMark value={priceRange[0] + priceRange[1] / 2} mt='4' ml='-9' fontSize='sm'>
-            {(priceRange[0] + priceRange[1] / 2).toLocaleString()}
-          </RangeSliderMark>
-          <RangeSliderMark value={priceRange[1]} mt='4' ml='-2.5' fontSize='sm'>
-            {priceRange[1].toLocaleString()}
+          <RangeSliderMark value={dataPriceRange[0]} mt='4' ml='-2.5' fontSize='sm'>
+            {dataPriceRange[0].toLocaleString()}
           </RangeSliderMark>
           <RangeSliderMark
-            value={minMaxPrice[0]}
+            value={dataPriceRange[0] + dataPriceRange[1] / 2}
+            mt='4'
+            ml='-9'
+            fontSize='sm'
+          >
+            {(dataPriceRange[0] + dataPriceRange[1] / 2).toLocaleString()}
+          </RangeSliderMark>
+          <RangeSliderMark value={dataPriceRange[1]} mt='4' ml='-2.5' fontSize='sm'>
+            {dataPriceRange[1].toLocaleString()}
+          </RangeSliderMark>
+          <RangeSliderMark
+            value={userMinMaxPrice[0]}
             textAlign='center'
             bg='gray.500'
             color='white'
@@ -131,10 +136,10 @@ const Main = () => {
             ml='-5'
             w='12'
           >
-            {minMaxPrice[0]}
+            {userMinMaxPrice[0]}
           </RangeSliderMark>
           <RangeSliderMark
-            value={minMaxPrice[1]}
+            value={userMinMaxPrice[1]}
             textAlign='center'
             bg='gray.500'
             color='white'
@@ -142,7 +147,7 @@ const Main = () => {
             ml='-5'
             w='12'
           >
-            {minMaxPrice[1]}
+            {userMinMaxPrice[1]}
           </RangeSliderMark>
           <RangeSliderTrack bg='gray.300'>
             <RangeSliderFilledTrack bg='gray.500' />
@@ -159,7 +164,7 @@ const Main = () => {
           </Button>
         </Link>
         <Grid templateColumns='repeat(2,1fr)' gap={10}>
-          {filteredData.map(product => (
+          {filteredDatas.map(product => (
             <TravleContent {...product} key={product.idx} />
           ))}
         </Grid>

--- a/src/pages/TravleListPage.tsx
+++ b/src/pages/TravleListPage.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Box, Grid, Button } from '@chakra-ui/react';
+import { Box, Grid, Button, Text } from '@chakra-ui/react';
 import MainLayout from 'components/MainLayout';
 import TravleContent from 'components/TravleContent';
 
 import { useLoaderData, Link } from 'react-router-dom';
 import { travleContent } from 'types';
+import { CheckIcon } from '@chakra-ui/icons';
 
 const Main = () => {
   const data = useLoaderData() as travleContent[];
@@ -12,8 +13,9 @@ const Main = () => {
     <MainLayout>
       <Box as='section'>
         <Link to='/reservations'>
-          <Button marginBottom={'3'} minW={'200px'}>
-            장바구니
+          <Button marginBottom={'3'} minW={'200px'} fontSize='m'>
+            <CheckIcon boxSize={'1.5rem'} marginRight={'2'} />
+            <Text>장바구니</Text>
           </Button>
         </Link>
         <Grid templateColumns='repeat(2,1fr)' gap={10}>

--- a/src/pages/TravleListPage.tsx
+++ b/src/pages/TravleListPage.tsx
@@ -1,5 +1,17 @@
-import React from 'react';
-import { Box, Grid, Button, Text } from '@chakra-ui/react';
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Grid,
+  Button,
+  Text,
+  HStack,
+  RangeSlider,
+  RangeSliderTrack,
+  RangeSliderFilledTrack,
+  RangeSliderThumb,
+  Tag,
+  Heading,
+} from '@chakra-ui/react';
 import MainLayout from 'components/MainLayout';
 import TravleContent from 'components/TravleContent';
 
@@ -7,11 +19,79 @@ import { useLoaderData, Link } from 'react-router-dom';
 import { travleContent } from 'types';
 import { CheckIcon } from '@chakra-ui/icons';
 
+const setSelectLocation = new Set();
+
 const Main = () => {
   const data = useLoaderData() as travleContent[];
+
+  const [filteredData, setFilteredData] = useState(data);
+  const [locationArr, setLocationArr] = useState<string[]>([]);
+
+  useEffect(() => {
+    setLocationArr(
+      data.reduce<string[]>((acc, cur) => {
+        if (!acc.includes(cur.spaceCategory)) acc.push(cur.spaceCategory);
+        return acc;
+      }, []),
+    );
+  }, []);
+
+  const onClick = (e: React.MouseEvent) => {
+    const element = e.target as HTMLElement;
+
+    setSelectLocation.has(element.innerHTML)
+      ? setSelectLocation.delete(element.innerHTML)
+      : setSelectLocation.add(element.innerHTML);
+
+    const filtered = data.filter(cur => setSelectLocation.has(cur.spaceCategory));
+
+    setFilteredData(filtered);
+  };
+
   return (
     <MainLayout>
-      <Box as='section'>
+      <Box
+        width={'725.33px'}
+        zIndex={2}
+        position={'fixed'}
+        borderWidth='1px'
+        borderRadius='lg'
+        background={'white'}
+        minH={'150px'}
+        top={'20px'}
+        padding={'10px 100px'}
+        shadow={'3px 3px 5px #cacaca5c'}
+      >
+        <Heading fontSize={'2xl'} marginTop={'10px'} marginBottom={'10px'}>
+          필터
+        </Heading>
+        <HStack spacing={4}>
+          {locationArr.map(e => {
+            return (
+              <Tag
+                key={e}
+                size={'lg'}
+                variant='subtle'
+                colorScheme='blackAlpha'
+                bg={setSelectLocation.has(e) ? 'gray.400' : 'gray.200'}
+                onClick={e => onClick(e)}
+                cursor={'pointer'}
+                fontWeight='black'
+              >
+                {e}
+              </Tag>
+            );
+          })}
+        </HStack>
+        <RangeSlider defaultValue={[120, 240]} min={0} max={300} step={30} marginTop={'20px'}>
+          <RangeSliderTrack>
+            <RangeSliderFilledTrack />
+          </RangeSliderTrack>
+          <RangeSliderThumb boxSize={6} index={0} />
+          <RangeSliderThumb boxSize={6} index={1} />
+        </RangeSlider>
+      </Box>
+      <Box as='section' marginTop={'120px'}>
         <Link to='/reservations'>
           <Button marginBottom={'3'} minW={'200px'} fontSize='m'>
             <CheckIcon boxSize={'1.5rem'} marginRight={'2'} />
@@ -19,7 +99,7 @@ const Main = () => {
           </Button>
         </Link>
         <Grid templateColumns='repeat(2,1fr)' gap={10}>
-          {data.map(product => (
+          {filteredData.map(product => (
             <TravleContent {...product} key={product.idx} />
           ))}
         </Grid>

--- a/src/pages/TravleListPage.tsx
+++ b/src/pages/TravleListPage.tsx
@@ -12,6 +12,7 @@ import {
   Tag,
   Heading,
   Divider,
+  RangeSliderMark,
 } from '@chakra-ui/react';
 import MainLayout from 'components/MainLayout';
 import TravleContent from 'components/TravleContent';
@@ -19,6 +20,7 @@ import TravleContent from 'components/TravleContent';
 import { useLoaderData, Link } from 'react-router-dom';
 import { travleContent } from 'types';
 import { CheckIcon } from '@chakra-ui/icons';
+import { FilterBox, MyCustomTag } from './Styles';
 
 enum StateSelect {
   ALL_SLELCT = '전체 선택하기',
@@ -78,52 +80,29 @@ const Main = () => {
 
   return (
     <MainLayout>
-      <Box
-        width={'725.33px'}
-        zIndex={2}
-        position={'fixed'}
-        borderWidth='1px'
-        borderRadius='lg'
-        background={'white'}
-        minH={'180px'}
-        top={'20px'}
-        padding={'10px 100px'}
-        shadow={'3px 3px 5px #cacaca5c'}
-      >
+      <FilterBox>
         <Heading fontSize={'2xl'} marginTop={'10px'} marginBottom={'10px'}>
           필터
         </Heading>
         <HStack spacing={4} marginBottom={'20px'}>
           {locationArr.map(e => {
             return (
-              <Tag
+              <MyCustomTag
                 key={e}
-                size={'lg'}
-                variant='subtle'
-                colorScheme='blackAlpha'
                 bg={setSelectLocation.has(e) ? 'gray.400' : 'gray.200'}
                 onClick={e => onClick(e)}
-                cursor={'pointer'}
-                fontWeight='black'
               >
                 {e}
-              </Tag>
+              </MyCustomTag>
             );
           })}
-          <Tag
-            size={'lg'}
-            variant='subtle'
-            colorScheme='blackAlpha'
-            bg={'gray.200'}
-            fontWeight='black'
-            cursor={'pointer'}
-            onClick={e => onClick(e)}
-          >
+          <MyCustomTag bg={'gray.200'} onClick={e => onClick(e)}>
             {StateSelect.ALL_SLELCT}
-          </Tag>
+          </MyCustomTag>
         </HStack>
         <Divider />
         <RangeSlider
+          aria-label={['min', 'max']}
           defaultValue={[priceRange[0], priceRange[1]]}
           min={priceRange[0]}
           max={priceRange[1]}
@@ -131,21 +110,46 @@ const Main = () => {
           marginTop={'20px'}
           onChange={e => onChange(e)}
         >
-          <RangeSliderTrack>
-            <RangeSliderFilledTrack />
-          </RangeSliderTrack>
-          <RangeSliderThumb boxSize={10} index={0}>
+          <RangeSliderMark value={priceRange[0]} mt='1' ml='-2.5' fontSize='sm'>
+            {priceRange[0].toLocaleString()}
+          </RangeSliderMark>
+          <RangeSliderMark value={priceRange[0] + priceRange[1] / 2} mt='1' ml='-2.5' fontSize='sm'>
+            {(priceRange[0] + priceRange[1] / 2).toLocaleString()}
+          </RangeSliderMark>
+          <RangeSliderMark value={priceRange[1]} mt='1' ml='-2.5' fontSize='sm'>
+            {priceRange[1].toLocaleString()}
+          </RangeSliderMark>
+          <RangeSliderMark
+            value={minMaxPrice[0]}
+            textAlign='center'
+            bg='gray.500'
+            color='white'
+            mt='-10'
+            ml='-5'
+            w='12'
+          >
             {minMaxPrice[0]}
-          </RangeSliderThumb>
-          <RangeSliderThumb boxSize={8} index={1}>
+          </RangeSliderMark>
+          <RangeSliderMark
+            value={minMaxPrice[1]}
+            textAlign='center'
+            bg='gray.500'
+            color='white'
+            mt='-10'
+            ml='-5'
+            w='12'
+          >
             {minMaxPrice[1]}
-          </RangeSliderThumb>
+          </RangeSliderMark>
+          <RangeSliderTrack bg='gray.300'>
+            <RangeSliderFilledTrack bg='gray.500' />
+          </RangeSliderTrack>
+          <RangeSliderThumb boxSize={6} index={0} />
+          <RangeSliderThumb boxSize={6} index={1} />
         </RangeSlider>
-        <HStack spacing='400px'>
-          <Text minW={'20'}>{priceRange[0].toLocaleString() + '원'}</Text>
-          <Text minW={'20'}>{priceRange[1].toLocaleString() + '원'}</Text>
-        </HStack>
-      </Box>
+        {/* <MyCustomRangeSlider onChange={e => onChange(e)} priceRange={priceRange} /> */}
+        <HStack spacing='400px'></HStack>
+      </FilterBox>
       <Box as='section' marginTop={'120px'}>
         <Link to='/reservations'>
           <Button marginBottom={'3'} minW={'200px'} fontSize='m'>

--- a/src/pages/TravleListPage.tsx
+++ b/src/pages/TravleListPage.tsx
@@ -48,8 +48,9 @@ const Main = () => {
   // DETERMINED MIN MAX PRICE OF THE DATA
   let min = datas[0].price;
   let max = datas[0].price;
-  datas.forEach(data => {
-    data.price < min ? (min = data.price) : (max = data.price);
+  datas.forEach(e => {
+    if (e.price < min) min = e.price;
+    else if (e.price > max) max = e.price;
   });
   dataPriceRange[0] = min;
   dataPriceRange[1] = max;

--- a/src/pages/TravleListPage.tsx
+++ b/src/pages/TravleListPage.tsx
@@ -11,6 +11,7 @@ import {
   RangeSliderThumb,
   Tag,
   Heading,
+  Divider,
 } from '@chakra-ui/react';
 import MainLayout from 'components/MainLayout';
 import TravleContent from 'components/TravleContent';
@@ -19,13 +20,18 @@ import { useLoaderData, Link } from 'react-router-dom';
 import { travleContent } from 'types';
 import { CheckIcon } from '@chakra-ui/icons';
 
+enum StateSelect {
+  ALL_SLELCT = '전체 선택하기',
+}
+
 const setSelectLocation = new Set();
+const priceRange = [0, 0];
 
 const Main = () => {
   const data = useLoaderData() as travleContent[];
-
   const [filteredData, setFilteredData] = useState(data);
   const [locationArr, setLocationArr] = useState<string[]>([]);
+  const [minMaxPrice, setMinMaxPrice] = useState<number[]>([0, 0]);
 
   useEffect(() => {
     setLocationArr(
@@ -36,16 +42,38 @@ const Main = () => {
     );
   }, []);
 
+  let min = data[0].price;
+  let max = data[0].price;
+  data.forEach(e => {
+    if (e.price < min) min = e.price;
+    else if (e.price > max) max = e.price;
+  });
+  priceRange[0] = min;
+  priceRange[1] = max;
+
+  useEffect(() => {
+    setMinMaxPrice([min, max]);
+  }, []);
+
   const onClick = (e: React.MouseEvent) => {
     const element = e.target as HTMLElement;
-
-    setSelectLocation.has(element.innerHTML)
-      ? setSelectLocation.delete(element.innerHTML)
-      : setSelectLocation.add(element.innerHTML);
+    if (element.innerHTML === StateSelect.ALL_SLELCT) {
+      locationArr.forEach(e => setSelectLocation.add(e));
+    } else {
+      setSelectLocation.has(element.innerHTML)
+        ? setSelectLocation.delete(element.innerHTML)
+        : setSelectLocation.add(element.innerHTML);
+    }
 
     const filtered = data.filter(cur => setSelectLocation.has(cur.spaceCategory));
 
     setFilteredData(filtered);
+  };
+
+  const onChange = (e: number[]) => {
+    const [min, max] = e;
+    setFilteredData(data.filter(e => e.price >= min && e.price <= max));
+    setMinMaxPrice([min, max]);
   };
 
   return (
@@ -57,7 +85,7 @@ const Main = () => {
         borderWidth='1px'
         borderRadius='lg'
         background={'white'}
-        minH={'150px'}
+        minH={'180px'}
         top={'20px'}
         padding={'10px 100px'}
         shadow={'3px 3px 5px #cacaca5c'}
@@ -65,7 +93,7 @@ const Main = () => {
         <Heading fontSize={'2xl'} marginTop={'10px'} marginBottom={'10px'}>
           필터
         </Heading>
-        <HStack spacing={4}>
+        <HStack spacing={4} marginBottom={'20px'}>
           {locationArr.map(e => {
             return (
               <Tag
@@ -82,14 +110,41 @@ const Main = () => {
               </Tag>
             );
           })}
+          <Tag
+            size={'lg'}
+            variant='subtle'
+            colorScheme='blackAlpha'
+            bg={'gray.200'}
+            fontWeight='black'
+            cursor={'pointer'}
+            onClick={e => onClick(e)}
+          >
+            {StateSelect.ALL_SLELCT}
+          </Tag>
         </HStack>
-        <RangeSlider defaultValue={[120, 240]} min={0} max={300} step={30} marginTop={'20px'}>
+        <Divider />
+        <RangeSlider
+          defaultValue={[priceRange[0], priceRange[1]]}
+          min={priceRange[0]}
+          max={priceRange[1]}
+          step={1000}
+          marginTop={'20px'}
+          onChange={e => onChange(e)}
+        >
           <RangeSliderTrack>
             <RangeSliderFilledTrack />
           </RangeSliderTrack>
-          <RangeSliderThumb boxSize={6} index={0} />
-          <RangeSliderThumb boxSize={6} index={1} />
+          <RangeSliderThumb boxSize={10} index={0}>
+            {minMaxPrice[0]}
+          </RangeSliderThumb>
+          <RangeSliderThumb boxSize={8} index={1}>
+            {minMaxPrice[1]}
+          </RangeSliderThumb>
         </RangeSlider>
+        <HStack spacing='400px'>
+          <Text minW={'20'}>{priceRange[0].toLocaleString() + '원'}</Text>
+          <Text minW={'20'}>{priceRange[1].toLocaleString() + '원'}</Text>
+        </HStack>
       </Box>
       <Box as='section' marginTop={'120px'}>
         <Link to='/reservations'>

--- a/src/pages/TravleListPage.tsx
+++ b/src/pages/TravleListPage.tsx
@@ -9,7 +9,6 @@ import {
   RangeSliderTrack,
   RangeSliderFilledTrack,
   RangeSliderThumb,
-  Tag,
   Heading,
   Divider,
   RangeSliderMark,
@@ -82,7 +81,7 @@ const Main = () => {
     <MainLayout>
       <FilterBox>
         <Heading fontSize={'2xl'} marginTop={'10px'} marginBottom={'10px'}>
-          필터
+          위치 필터
         </Heading>
         <HStack spacing={4} marginBottom={'20px'}>
           {locationArr.map(e => {
@@ -100,7 +99,10 @@ const Main = () => {
             {StateSelect.ALL_SLELCT}
           </MyCustomTag>
         </HStack>
-        <Divider />
+        <Divider marginBottom={'8'} />
+        <Heading fontSize={'2xl'} marginTop={'10px'} marginBottom={'15px'}>
+          금액 필터
+        </Heading>
         <RangeSlider
           aria-label={['min', 'max']}
           defaultValue={[priceRange[0], priceRange[1]]}
@@ -108,15 +110,16 @@ const Main = () => {
           max={priceRange[1]}
           step={1000}
           marginTop={'20px'}
+          marginBottom={'20px'}
           onChange={e => onChange(e)}
         >
-          <RangeSliderMark value={priceRange[0]} mt='1' ml='-2.5' fontSize='sm'>
+          <RangeSliderMark value={priceRange[0]} mt='4' ml='-2.5' fontSize='sm'>
             {priceRange[0].toLocaleString()}
           </RangeSliderMark>
-          <RangeSliderMark value={priceRange[0] + priceRange[1] / 2} mt='1' ml='-2.5' fontSize='sm'>
+          <RangeSliderMark value={priceRange[0] + priceRange[1] / 2} mt='4' ml='-9' fontSize='sm'>
             {(priceRange[0] + priceRange[1] / 2).toLocaleString()}
           </RangeSliderMark>
-          <RangeSliderMark value={priceRange[1]} mt='1' ml='-2.5' fontSize='sm'>
+          <RangeSliderMark value={priceRange[1]} mt='4' ml='-2.5' fontSize='sm'>
             {priceRange[1].toLocaleString()}
           </RangeSliderMark>
           <RangeSliderMark
@@ -147,10 +150,8 @@ const Main = () => {
           <RangeSliderThumb boxSize={6} index={0} />
           <RangeSliderThumb boxSize={6} index={1} />
         </RangeSlider>
-        {/* <MyCustomRangeSlider onChange={e => onChange(e)} priceRange={priceRange} /> */}
-        <HStack spacing='400px'></HStack>
       </FilterBox>
-      <Box as='section' marginTop={'120px'}>
+      <Box as='section' marginTop={'40px'}>
         <Link to='/reservations'>
           <Button marginBottom={'3'} minW={'200px'} fontSize='m'>
             <CheckIcon boxSize={'1.5rem'} marginRight={'2'} />

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,7 +4,7 @@ import TravleListPage from 'pages/TravleListPage';
 import { createBrowserRouter } from 'react-router-dom';
 import mainLoader from 'router/loader/mainLoader';
 import rootLoader from 'router/loader/rootLoader';
-import ReservationPage from './../pages/ReservationPage';
+import ReservationPage from 'pages/ReservationPage';
 
 const router = createBrowserRouter([
   {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,6 +4,7 @@ import TravleListPage from 'pages/TravleListPage';
 import { createBrowserRouter } from 'react-router-dom';
 import mainLoader from 'router/loader/mainLoader';
 import rootLoader from 'router/loader/rootLoader';
+import ReservationPage from './../pages/ReservationPage';
 
 const router = createBrowserRouter([
   {
@@ -18,7 +19,7 @@ const router = createBrowserRouter([
   },
   {
     path: PATH_ROUTES.shopBasket,
-    element: <TravleListPage />,
+    element: <ReservationPage />,
   },
 ]);
 


### PR DESCRIPTION
# 필터링 기능 구현

🔔  `feature/#3`에 기존 `feature/#3-seo0h`  가 able to merge가 안떠서 `feature/#3 seo0h-temp`로 브랜치를 새로 파고 기존 변경 사항을 적용 했습니다. 기존 브랜치는 삭제했습니다.

![image](https://user-images.githubusercontent.com/108770949/224280086-e47a6bfe-436c-49c7-9837-cb6f8c383c6c.png)


- 여행 상품 리스트의 가격(price), 공간(spaceCategory) 필터 기능을 만들어주세요.
    - [x]  [[예시) 0~1000, 1500~3000](https://github.com/wanted-onboarding-10team/pre-onboarding-9th-2-10/compare/feature/%233...feature/%EA%B0%80%EA%B2%A9)](가격)
    - [x]  [예시) 서울, 부산] (공간)
    - [x]  개별 필터링과, 다중 필터링이 모두 가능하도록 구현해주세요

주어진 데이터가 바뀔 수도 있기 때문에 관련 필터의 초깃값을 mock_data를 기준으로 만들었습니다.